### PR TITLE
tk

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,7 +1,6 @@
 git+https://github.com/rsichny/swagger-py.git  # the digium release does not support python3
 https://github.com/wazo-platform/ari-py/archive/0.4.0.zip
 https://github.com/wazo-platform/wazo-test-helpers/archive/master.zip
-docker-compose
 kombu
 pyhamcrest
 pytest


### PR DESCRIPTION
use docker-compose from binary instead of python

why: to have the latest docker-compose