### PR TITLE
tests: disable stderr output for run container

### DIFF
--- a/integration_tests/suite/test_amqp.py
+++ b/integration_tests/suite/test_amqp.py
@@ -1,4 +1,4 @@
-# Copyright 2019-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2019-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -41,7 +41,7 @@ class AssetLauncher(AssetLaunchingTestCase):
 
     @classmethod
     def check_amqp_refcount(cls) -> None:
-        amqp_leaks = cls.run_container('refcount')
+        amqp_leaks = cls.run_container('refcount', stderr=False)
         # This is the output of refcounter.py grepped on amqp.
         # See full output with TEST_LOGS=verbose
         # See https://docs.asterisk.org/Development/Debugging/Reference-Count-Debugging/


### PR DESCRIPTION
Depends-on: https://github.com/wazo-platform/wazo-test-helpers/pull/125

Note: Since this repo is not a python repository, our injection mechanism with Depends-on into the virtualenv won't work

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> - **Testing change:** `AssetLauncher.check_amqp_refcount()` now calls `run_container('refcount', stderr=False)` to suppress stderr during the refcount check in `test_amqp.py`.
> - **Minor:** Update copyright header to 2019–2026.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d41da5ae0822f2b9b13094e6c0577b2faa2ea96d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->