### PR TITLE
docker: pin rabbitmq to version 3

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     command: "asterisk -fTvvvvv"
 
   rabbitmq:
-    image: rabbitmq
+    image: rabbitmq:3
     ports:
       - 5672
     volumes:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only pins the RabbitMQ Docker image version used by integration tests, reducing variability without changing application code paths.
> 
> **Overview**
> Pins the integration-test `docker-compose.yml` RabbitMQ service from `rabbitmq` (latest) to `rabbitmq:3` to make the test environment deterministic and avoid unexpected upstream image changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8576e84dfa5b37e42b7be7934b9f061c4fc14787. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->